### PR TITLE
Fix Duration metrics conversion

### DIFF
--- a/wavefront/wavefront.go
+++ b/wavefront/wavefront.go
@@ -111,6 +111,8 @@ func translateToInt64(value interface{}) (int64, error) {
 		return v, nil
 	case float64:
 		return int64(v), nil
+	case *policy.Duration:
+		return int64(v.GetValue().GetNanos()), nil
 	default:
 		return 0, fmt.Errorf("couldn't convert %s to int64", value)
 	}


### PR DESCRIPTION
Metrics like `response.duration` rely on the `Duration` type for storing values. A conversion of such a value wasn't in place as Istio 1.0.1 which we rely on doesn't support `Duration` based metrics. This commit will however benefit future updates of Istio where it can handle `Duration` based metrics. This has also been tested with 1.1.0.snapshot.1.

A caveat to note is, after adding `Duration` support in Istio, the `flushInterval` parameter in the `sample_operator_config.yaml` can no longer be a `map`, and instead has to be a `string` like `flushInterval: 5s` or so.

Signed-off-by: Venil Noronha <veniln@vmware.com>

See #3 for more information.