### PR TITLE
Pin wavefront-adapter-for-istio image to 0.1.0

### DIFF
--- a/config/wavefront-adapter.yaml
+++ b/config/wavefront-adapter.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: wavefront
-        image: vmware/wavefront-adapter-for-istio:latest
+        image: vmware/wavefront-adapter-for-istio:0.1.0
         imagePullPolicy: Always
         ports:
         - containerPort: 8000


### PR DESCRIPTION
**Description**
This PR pins the vmware/wavefront-adapter-for-istio image to 0.1.0.