### PR TITLE
Update link to adapter on the istio.io website

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ params:
     address: YOUR-PROXY-IP:YOUR-PROXY-PORT
 ```
 
-See the [reference docs](https://preliminary.istio.io/docs/reference/config/policy-and-telemetry/adapters/wavefront/)
+See the [reference docs](https://istio.io/docs/reference/config/policy-and-telemetry/adapters/wavefront/)
 for the available configuration parameters.
 
 ### Deployment


### PR DESCRIPTION
**Description**
Previously, the link to the reference docs pointed to the preliminary website. This PR updates the link to point to the release 1.0 website.