### PR TITLE
Add reporter attribute to requestcount metric

### DIFF
--- a/config/sample_operator_config.yaml
+++ b/config/sample_operator_config.yaml
@@ -29,6 +29,7 @@ spec:
   params:
     value: 1
     dimensions:
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "client", "server")
       source_service: source.workload.name | "unknown"
       source_service_namespace: source.workload.namespace | "unknown"
       source_version: source.labels["version"] | "unknown"


### PR DESCRIPTION
**Description**
This PR adds a new `reporter` attribute to the existing `requestcount` metric to determine the reporter of the request, and effectively to show the correct number of client requests on the Wavefront interface.

**Additional context**
Fixes #15
