### PR TITLE
Remove pack-config make target

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -67,14 +67,6 @@ To run the unit tests, use the following command:
 make test
 ```
 
-## Packing Configuration
-
-To pack configuration files for releases, use the following command:
-
-```shell
-make pack-config
-```
-
 # Dry-Running Helm
 
 To dry-run the helm chart, use the following command:

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ help:
 	@echo "    helm-print         Dry run and print the Helm manifest."
 	@echo "    helm-generate      Generate the manifest from Helm configuration."
 	@echo "    help               Show this help message."
-	@echo "    pack-config        Create configuration archives."
 	@echo "    setup              Set up the development environment."
 	@echo "    test               Run all unit tests."
 	@echo "    vendor-get <pkg>   Add a new dependency to the vendor directory."
@@ -116,15 +115,6 @@ helm-generate:
 .PHONY: format
 format: setup
 	@$(GOIMPORTS) -w -l $(FILES)
-
-# Creates configuration archives
-# Usage: make pack-config
-.PHONY: pack-config
-pack-config:
-	rm -rf config.tar.gz config.zip
-	tar -zcvf config.tar.gz config
-	zip -r config.zip config
-	@echo "Configurations were packed successfully!"
 
 # Adds a new dependency to glide.yaml, glide.lock and to the vendor directory
 # Usage: make vendor-get <pkg>


### PR DESCRIPTION
**Description**
This PR removes the `pack-config` target in favor of Helm generated YAML configuration.