### PR TITLE
Fix CircleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,5 +6,5 @@ jobs:
     working_directory: /go/src/github.com/vmware/wavefront-adapter-for-istio
     steps:
       - checkout
-      - run: make build
-      - run: make test
+      - run: go build -v ./...
+      - run: go test -v ./...


### PR DESCRIPTION
**Description**
This PR replaces make targets in the CircleCI config with simple go commands in order to simplify the configuration on the CI system.