### PR TITLE
Update request/response size attribute config

### DIFF
--- a/install/config.yaml
+++ b/install/config.yaml
@@ -326,7 +326,7 @@ metadata:
 spec:
   template: metric
   params:
-    value: request.size | 0
+    value: request.total_size | 0
     dimensions:
       reporter: conditional((context.reporter.kind | "inbound") == "outbound", "client", "server")
       source_service: source.workload.name | "unknown"
@@ -389,7 +389,7 @@ metadata:
 spec:
   template: metric
   params:
-    value: response.size | 0
+    value: response.total_size | 0
     dimensions:
       reporter: conditional((context.reporter.kind | "inbound") == "outbound", "client", "server")
       source_service: source.workload.name | "unknown"
@@ -405,7 +405,7 @@ spec:
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
-  name: wavefront-rule
+  name: wavefront-http-rule
   namespace: istio-system
 spec:
   actions:

--- a/install/wavefront/templates/http-instances.tpl
+++ b/install/wavefront/templates/http-instances.tpl
@@ -9,7 +9,7 @@ metadata:
 spec:
   template: metric
   params:
-    value: request.size | 0
+    value: request.total_size | 0
     dimensions:
       {{- template "attributes.service" }}
       response_code: response.code | 200
@@ -54,7 +54,7 @@ metadata:
 spec:
   template: metric
   params:
-    value: response.size | 0
+    value: response.total_size | 0
     dimensions:
       {{- template "attributes.service" }}
       response_code: response.code | 200

--- a/install/wavefront/templates/http-rule.tpl
+++ b/install/wavefront/templates/http-rule.tpl
@@ -4,7 +4,7 @@
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
-  name: wavefront-rule
+  name: wavefront-http-rule
   namespace: istio-system
 spec:
   actions:


### PR DESCRIPTION
**Description**
This PR updates the request/response size attribute to capture the total request/response size inclusive of header, body and other data.

**Additional context**
See the [Istio attribute vocabulary](https://istio.io/docs/reference/config/policy-and-telemetry/attribute-vocabulary/) for more info.