### PR TITLE
Fix installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,13 @@
 Wavefront by VMware Adapter for Istio is an adapter for [Istio](https://istio.io)
 to publish metrics to [Wavefront by VMware](https://www.wavefront.com/).
 
-**Note:** This adapter is currently experimental. Therefore, caution should be
-taken before using it in production environments.
+This adapter is currently experimental. Therefore, caution should be taken
+before using it in production environments.
+
+**Note:** The `master` branch is used for active development and can become
+unstable. Please refer to the [Quick Start](https://github.com/vmware/wavefront-adapter-for-istio/tree/0.1.0#quick-start)
+from version [0.1.0](https://github.com/vmware/wavefront-adapter-for-istio/releases/tag/0.1.0)
+to install a stable version of the adapter.
 
 ## Quick Start
 
@@ -30,8 +35,8 @@ this adapter using Helm.
 
 1\. Download the configuration.
 
-```shell
-curl -LO https://raw.githubusercontent.com/vmware/wavefront-adapter-for-istio/master/install/config.yaml
+```console
+$ curl -LO https://raw.githubusercontent.com/vmware/wavefront-adapter-for-istio/0.1.1/install/config.yaml
 ```
 
 2\. If you want the metrics to be published to the Wavefront instance directly,
@@ -76,8 +81,8 @@ Execute the following command to configure the Istio Mixer to publish metrics to
 Wavefront using this adapter. This step must be performed after deploying
 [Istio](https://istio.io/docs/setup/kubernetes/quick-start/).
 
-```shell
-kubectl apply -f config.yaml
+```console
+$ kubectl apply -f config.yaml
 ```
 
 You should now be able to see Istio metrics on Wavefront under your configured
@@ -87,8 +92,8 @@ source (or `istio` by default).
 
 To uninstall this adapter, use the following command.
 
-```shell
-kubectl delete -f config.yaml
+```console
+$ kubectl delete -f config.yaml
 ```
 
 ## Contributing

--- a/install/wavefront/README.md
+++ b/install/wavefront/README.md
@@ -28,8 +28,8 @@ $ kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
 1\. Download the Helm chart configuration and extract it.
 
 ```console
-$ curl -LO https://github.com/vmware/wavefront-adapter-for-istio/releases/download/0.1.0/wavefront-0.1.0.tgz
-$ tar -zxvf wavefront-0.1.0.tgz
+$ curl -LO https://github.com/vmware/wavefront-adapter-for-istio/releases/download/0.1.1/wavefront-0.1.1.tgz
+$ tar -zxvf wavefront-0.1.1.tgz
 ```
 
 2\. If you want the metrics to be published to the Wavefront instance directly,


### PR DESCRIPTION
**Description**
This PR updates the adapter installation instructions in the README to reflect the unstable status of the `master` branch, and redirect users to the README from the latest pre-release version for a stable installation.