### PR TITLE
helm: update adapter Docker tag to 0.1.1

### DIFF
--- a/install/config.yaml
+++ b/install/config.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
       - name: wavefront
-        image: vmware/wavefront-adapter-for-istio:0.1.0
+        image: vmware/wavefront-adapter-for-istio:0.1.1
         imagePullPolicy: Always
         ports:
         - containerPort: 8000


### PR DESCRIPTION
**Description**
This updates the Docker image tag in the Helm manifest to point to the latest released adapter version `0.1.1`.