### PR TITLE
Issue #73 - Comment out proxy & direct nodes from values, improve helm readme

### DIFF
--- a/install/wavefront/README.md
+++ b/install/wavefront/README.md
@@ -40,7 +40,14 @@ $ curl -LO https://github.com/vmware/wavefront-adapter-for-istio/releases/downlo
 $ tar -zxvf wavefront-0.1.1.tgz
 ```
 
-2\. If you want the metrics to be published to the Wavefront instance directly,
+2\. The configuration used per helm deployment is specified in the `wavefront/values.yaml`
+
+**Note:** Helm will pick the `direct` credentials by default. If you wish to
+ingest metrics via a Proxy, please ensure that the `direct` credentials are
+either deleted or commented before deploying.
+
+
+3\. If you want the metrics to be published to the Wavefront instance directly,
 supply the `direct` params in `values.yaml` like so:
 
 ```yaml
@@ -62,11 +69,7 @@ credentials:
     address: YOUR-PROXY-IP:YOUR-PROXY-PORT
 ```
 
-**Note:** Helm will pick the `direct` credentials by default. If you wish to
-ingest metrics via a Proxy, please ensure that the `direct` credentials are
-either deleted or commented before deploying.
-
-3\. It is recommended that you update the `source` attribute to a reasonable
+4\. It is recommended that you update the `source` attribute to a reasonable
 value, for example, to your cluster name.
 
 ```yaml

--- a/install/wavefront/values.yaml
+++ b/install/wavefront/values.yaml
@@ -2,12 +2,13 @@ adapter:
   image: vmware/wavefront-adapter-for-istio
   tag: 0.1.1
 
-credentials:
-  direct:
-    server: https://YOUR-INSTANCE.wavefront.com
-    token: YOUR-API-TOKEN
-  proxy:
-    address: YOUR-PROXY-IP:YOUR-PROXY-PORT
+credentials:  # Define either direct or proxy in the credentials node:
+#  direct:
+#    server: https://YOUR-INSTANCE.wavefront.com
+#    token: YOUR-API-TOKEN
+
+#  proxy:
+#    address: YOUR-PROXY-IP:YOUR-PROXY-PORT
 
 metrics:
   flushInterval: 5s


### PR DESCRIPTION
**Description**
Comment out both `proxy` and `direct` nodes in the `values.yml` to allow the implementer to use one or specify their own in a deployment specific values file created outside of the repo.

Moved the Note about defining only one of the credential nodes earlier in the Helm readme for better clarification.

**Additional context**
Fixes #73 