### PR TITLE
Add resource limits to the "wavefront" deployment.

### DIFF
--- a/install/wavefront/templates/adapter.yaml
+++ b/install/wavefront/templates/adapter.yaml
@@ -40,3 +40,10 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8000
+        resources:
+          requests:
+            cpu: 500m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi


### PR DESCRIPTION
**Description**

Adds `resources:` configuration to the adapter deployment object, both `requests:` and `limits:` 500m cpu and 256Mi memory.  This provides some protection against the adapter pods getting evicted in a busy cluster.

**Additional context**

Our Wavefront-Istio adapter was getting frequently evicted from the cluster.  #79 has an actual fix (the resource that was actually getting exceeded was "ephemeral storage", or local container filesystem space used up by logs) but adding resource constraints seems like generally good practice.