### PR TITLE
In the default Helm values.yaml file, don't provide `direct:` configuration.

### DIFF
--- a/install/wavefront/values.yaml
+++ b/install/wavefront/values.yaml
@@ -4,9 +4,9 @@ adapter:
 
 credentials:
 # Define either direct or proxy credentials.
-  direct:
-    server: https://YOUR-INSTANCE.wavefront.com
-    token: YOUR-API-TOKEN
+#  direct:
+#    server: https://YOUR-INSTANCE.wavefront.com
+#    token: YOUR-API-TOKEN
 #  proxy:
 #    address: YOUR-PROXY-IP:YOUR-PROXY-PORT
 


### PR DESCRIPTION
**Description**

Comment out the `direct:` configuration block in the default Helm `values.yaml` file.

**Additional context**

This is hard to disable as a downstream consumer if you have an in-cluster proxy; since there winds up being both `direct:` and `proxy:` configuration the proxy tries to send directly to Wavefront, which isn't actually correctly configured.

This PR is very similar to #75 (which addresses #73) but that got undone in #79.