### PR TITLE
In the http rule, specifically match HTTP non-probe requests.

### DIFF
--- a/install/wavefront/templates/http-rule.tpl
+++ b/install/wavefront/templates/http-rule.tpl
@@ -7,6 +7,10 @@ metadata:
   name: wavefront-http-rule
   namespace: {{ .Values.namespaces.istio }}
 spec:
+  match: >-
+    (context.protocol == "http" || context.protocol == "grpc") &&
+    (match((request.useragent | "-"), "kube-probe*") == false) &&
+    (match((request.useragent | "-"), "Prometheus*") == false)
   actions:
   - handler: wavefront-handler.{{ .Values.namespaces.istio }}
     instances:


### PR DESCRIPTION
**Description**

In the Istio `rule` object collecting HTTP metrics, add a `match:` clause that limits the rule to (a) only HTTP or gRPC requests, (b) not kube-probe requests, and (c) not Prometheus requests.

**Additional context**

This matches a similar match expression in the standard Istio Prometheus
handler (see also istio/istio#12251).  Without this, we see inbound request metrics from health checks, and outbound HTTP request metrics for background non-HTTP activity.