### PR TITLE
Standard and Helm installation fix to create "wavefront-istio" namespace

### DIFF
--- a/install/config.yaml
+++ b/install/config.yaml
@@ -1,4 +1,10 @@
 ---
+# namespace for adapter wavefront
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: wavefront-istio
+---
 # Source: wavefront/templates/adapter.yaml
 # service for adapter wavefront
 apiVersion: v1

--- a/install/wavefront/templates/adapter.yaml
+++ b/install/wavefront/templates/adapter.yaml
@@ -1,3 +1,10 @@
+---
+# namespace for adapter wavefront
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespaces.adapter }}
+---
 # service for adapter wavefront
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
**Description**
Fix for Standard and Helm installation to create the required namespace during installation.
config.yaml file modified to create "wavefront-istio" namespace during the Standard installation.
adapter.yaml file is modified to take the name from values.yaml and create the namespace during Helm installation.

**Additional context**
Jira Ticket: https://wavefront.atlassian.net/browse/INT-532
Reviewers: @vikramraman & @laullon 