### PR TITLE
Report default adapter metrics every 60sec.

### DIFF
--- a/wavefront/system_stats.go
+++ b/wavefront/system_stats.go
@@ -26,7 +26,7 @@ import (
 )
 
 // delay between memory and cpu metrics sample
-const delay = 5 * time.Second
+const delay = 60 * time.Second
 
 // createSystemStatsReporter creates a reporter that periodically flushes adapter system metrics to Wavefront.
 func createSystemStatsReporter(hostTags map[string]string) {


### PR DESCRIPTION
**Description**
{{ Succinctly describe your change }}

**Additional context**
{{ Add any other context about the change here, for example, Fixes #issue-number }}
