### PR TITLE
INT-657: Istio helm chart support for K8s v1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ istioctl install --set values.prometheus.enabled=true --set values.telemetry.v1.
 
 1\. Download the configuration.
 
+For Kubernetes v1.17.0 or later
+```console
+$ curl -LO https://raw.githubusercontent.com/vmware/wavefront-adapter-for-istio/0.1.5/install/config.yaml
+```
+
+For Kubernetes v1.15.0 to v1.16.x
 ```console
 $ curl -LO https://raw.githubusercontent.com/vmware/wavefront-adapter-for-istio/0.1.4/install/config.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ this adapter using Helm.
 
 To deploy this adapter, you will need a cluster with the following setup.
 
-* Kubernetes v1.15.0
+* Kubernetes v1.17.0
 * Istio v1.4 or v1.5 or v1.6
 
 **Note:** From Istio v1.5.x onwards `Mixer` is disabled by default. Enable `Mixer` with the following step:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ this adapter using Helm.
 
 To deploy this adapter, you will need a cluster with the following setup.
 
-* Kubernetes v1.17.0
+* Kubernetes v1.15+
 * Istio v1.4 or v1.5 or v1.6
 
 **Note:** From Istio v1.5.x onwards `Mixer` is disabled by default. Enable `Mixer` with the following step:
@@ -52,14 +52,8 @@ istioctl install --set values.prometheus.enabled=true --set values.telemetry.v1.
 
 1\. Download the configuration.
 
-For Kubernetes v1.17.0 or later
 ```console
 $ curl -LO https://raw.githubusercontent.com/vmware/wavefront-adapter-for-istio/0.1.5/install/config.yaml
-```
-
-For Kubernetes v1.15.0 to v1.16.x
-```console
-$ curl -LO https://raw.githubusercontent.com/vmware/wavefront-adapter-for-istio/0.1.4/install/config.yaml
 ```
 
 2\. If you want the metrics to be published to the Wavefront instance directly,

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ to publish metrics to [Wavefront by VMware](https://www.wavefront.com/).
 
 
 **Note:** The `master` branch is used for active development and can become
-unstable. Please refer to the [Quick Start](https://github.com/vmware/wavefront-adapter-for-istio/tree/0.1.4#quick-start)
-from version [0.1.4](https://github.com/vmware/wavefront-adapter-for-istio/releases/tag/0.1.4)
+unstable. Please refer to the [Quick Start](https://github.com/vmware/wavefront-adapter-for-istio/tree/0.1.5#quick-start)
+from version [0.1.5](https://github.com/vmware/wavefront-adapter-for-istio/releases/tag/0.1.5)
 to install a stable version of the adapter.
 
 ## Quick Start

--- a/install/config.yaml
+++ b/install/config.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
       - name: wavefront
-        image: vmware/wavefront-adapter-for-istio:0.1.4
+        image: vmware/wavefront-adapter-for-istio:0.1.5
         imagePullPolicy: Always
         ports:
         - containerPort: 8000

--- a/install/config.yaml
+++ b/install/config.yaml
@@ -27,7 +27,7 @@ spec:
 ---
 # Source: wavefront/templates/adapter.yaml
 # deployment for adapter wavefront
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wavefront

--- a/install/wavefront/Chart.yaml
+++ b/install/wavefront/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: wavefront
-version: 0.1.4
+version: 0.1.5
 description: A Helm chart for Wavefront by VMware Adapter for Istio
 home: https://github.com/vmware/wavefront-adapter-for-istio/
 sources:

--- a/install/wavefront/templates/adapter.yaml
+++ b/install/wavefront/templates/adapter.yaml
@@ -24,7 +24,7 @@ spec:
     app: wavefront
 ---
 # deployment for adapter wavefront
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wavefront

--- a/install/wavefront/values.yaml
+++ b/install/wavefront/values.yaml
@@ -1,6 +1,6 @@
 adapter:
   image: vmware/wavefront-adapter-for-istio
-  tag: 0.1.4
+  tag: 0.1.5
 
 credentials:
 # Define either direct or proxy credentials.

--- a/wavefront/config/config.proto
+++ b/wavefront/config/config.proto
@@ -22,7 +22,7 @@ syntax = "proto3";
 // $contact_email: veniln@vmware.com
 // $support_link:
 // $source_link: https://github.com/vmware/wavefront-adapter-for-istio
-// $latest_release_link: https://github.com/vmware/wavefront-adapter-for-istio/releases/tag/0.1.4
+// $latest_release_link: https://github.com/vmware/wavefront-adapter-for-istio/releases/tag/0.1.5
 // $helm_chart_link:
 // $istio_versions: "1.4.9, 1.5.6, 1.6.2"
 // $supported_templates: metric

--- a/wavefront/config/wavefront.config.pb.html
+++ b/wavefront/config/wavefront.config.pb.html
@@ -8,7 +8,7 @@ provider: VMware, Inc.
 contact_email: veniln@vmware.com
 support_link:
 source_link: https://github.com/vmware/wavefront-adapter-for-istio
-latest_release_link: https://github.com/vmware/wavefront-adapter-for-istio/releases/tag/0.1.4
+latest_release_link: https://github.com/vmware/wavefront-adapter-for-istio/releases/tag/0.1.5
 helm_chart_link:
 istio_versions: "1.4.9, 1.5.6, 1.6.2"
 supported_templates: metric


### PR DESCRIPTION
**Description**
The Istio deployment apiVersion is updated to `apps/v1`
the Chart version is bumped up
And also minor changes to README

**Additional context**
Fixes [INT-657](https://wavefront.atlassian.net/browse/INT-657), [INT-727](https://wavefront.atlassian.net/browse/INT-727)(Duplicate of INT-657) and [#92](https://github.com/vmware/wavefront-adapter-for-istio/issues/92)